### PR TITLE
Fix for RT#78398: t/singlepart.t fails

### DIFF
--- a/t/singlepart.t
+++ b/t/singlepart.t
@@ -38,7 +38,7 @@ It's base64 encoded.
 END_BODY
 
 # $expected_body   =~ s/\n/\x0d\x0a/g;
-$expected_string =~ s/\n\z/\x0d\x0a/g;
+$expected_string =~ s/\n/\x0d\x0a/g;
 
 is $email->as_string, $expected_string, 'as_string matches';
 is $email->body,      $expected_body, 'body matches';


### PR DESCRIPTION
Hi, I came across the issue that the test t/singlepart.t fails. At first I assumed it was a Win32 issue - more or less because that is where I discovered it first and I did not assume the module test to be broken - but I can also reproduce it on my Linux laptop with multiple different perls.

This commit fixes it for me; basically in the 'expected' string all line feeds were removed so they do not match the returned string.
