### PR TITLE
fixed a bug that $differ flag is not set.

### DIFF
--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -734,7 +734,10 @@ sub walk_parts {
         =  (@subparts != @orig_subparts)
         || (grep { $subparts[$_] != $orig_subparts[$_] } (0 .. $#subparts));
 
-      $part->parts_set(\@subparts) if $differ;
+      if ($differ) {
+        $part->parts_set(\@subparts);
+        $part = bless {%$part}, ref($part);
+      }
     }
 
     return $part;

--- a/t/walk-parts.t
+++ b/t/walk-parts.t
@@ -62,6 +62,15 @@ $email->walk_parts(sub {
 is($called_parts_set, 1, "called parts_set once");
 like($email->as_string, qr/Part one/);
 
+$email->walk_parts(sub {
+  if ($_[0]->body and $_[0]->body eq 'Part one') {
+    $_[0] = Email::MIME->create(
+      body => 'Part ONE',
+    );
+  }
+});
+like($email->as_string, qr/Part ONE/);
+
 done_testing;
 
 __DATA__


### PR DESCRIPTION
Hi.

I encountered a bug similar to the following.

```
$email->walk_parts(
    sub {
        if ($_[0]->body eq ...) {
                $_[0] = Email::MIME->create( ... );
        }
    }
);
$email->as_string; # Not been changed. Original.
```

Find the bug, I was corrected.

It is a supplement to, but not correct test.

```
60 });
61
62 is($called_parts_set, 1, "called parts_set once");
    # The number of times that is called from Email/Mime.pm line 227.
    # It is not the thing was called from within the function Email::Mime::walk_parts.
63
64 done_testing;
```

Please merge this If it's ok with you.

Cheers,
Tomohiro Hosaka
