### PR TITLE
Call subparts in debug_structure

### DIFF
--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -397,8 +397,8 @@ sub debug_structure {
   $level ||= 0;
   my $rv = " " x (5 * $level);
   $rv .= "+ " . ($self->content_type || '') . "\n";
-  my @parts = $self->parts;
-  if (@parts > 1) { $rv .= $_->debug_structure($level + 1) for @parts; }
+  my @parts = $self->subparts;
+  $rv .= $_->debug_structure($level + 1) for @parts;
   return $rv;
 }
 


### PR DESCRIPTION
Allows debug_structure to properly print out the structure of multipart messages containing only a single part without deep recursion problems.