### PR TITLE
Use '$email' like the rest of the SYNOPSIS.

### DIFF
--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -83,7 +83,7 @@ by all means keep reading.
   $_->encoding_set( 'base64' ) for $email->parts;
 
   # Quick multipart creation
-  my $quicky = Email::MIME->create(
+  my $email = Email::MIME->create(
       header_str => [
           From => 'my@address',
           To   => 'your@address',


### PR DESCRIPTION
This allows the final block to be copied and used verbatim without
having to change '$email->as_string' to '$quicky->as_string'.