### PR TITLE
Email::MIME::Encode: Do not try to MIME-decode non-MIME headers

### DIFF
--- a/lib/Email/MIME/Encode.pm
+++ b/lib/Email/MIME/Encode.pm
@@ -8,7 +8,7 @@ use Encode ();
 use MIME::Base64();
 
 my %address_list_headers = map { $_ => undef } qw(from sender reply-to to cc bcc);
-my %no_mime_headers = map { $_ => undef } qw(date message-id in-reply-to references);
+my %no_mime_headers = map { $_ => undef } qw(date message-id in-reply-to references downgraded-message-id downgraded-in-reply-to downgraded-references);
 
 sub maybe_mime_encode_header {
     my ($header, $val, $charset) = @_;

--- a/lib/Email/MIME/Encode.pm
+++ b/lib/Email/MIME/Encode.pm
@@ -103,4 +103,28 @@ sub mime_encode {
     return join q{ }, @result;
 }
 
+sub maybe_mime_decode_header {
+    my ($header, $val) = @_;
+
+    $header = lc $header;
+    $header =~ s/^resent-//i;
+
+    return $val
+        if exists $no_mime_headers{$header};
+
+    return mime_decode($val);
+}
+
+sub mime_decode {
+    my ($text) = @_;
+    return undef unless defined $text;
+
+    # The eval is to cope with unknown encodings, like Latin-62, or other
+    # nonsense that gets put in there by spammers and weirdos
+    # -- rjbs, 2014-12-04
+    local $@;
+    my $result = eval { Encode::decode("MIME-Header", $text) };
+    return defined $result ? $result : $text;
+}
+
 1;

--- a/lib/Email/MIME/Header.pm
+++ b/lib/Email/MIME/Header.pm
@@ -43,7 +43,7 @@ sub header_str {
     next unless defined $header;
     next unless $header =~ /=\?/;
 
-    _maybe_decode(\$header);
+    _maybe_decode($_[0], \$header);
   }
   return $wanta ? @header : $header[0];
 }
@@ -68,22 +68,15 @@ sub header_str_pairs {
 
   my @pairs = $self->header_pairs;
   for (grep { $_ % 2 } (1 .. $#pairs)) {
-    _maybe_decode(\$pairs[$_]);
+    _maybe_decode($pairs[$_-1], \$pairs[$_]);
   }
 
   return @pairs;
 }
 
 sub _maybe_decode {
-  my ($str_ref) = @_;
-
-  # The eval is to cope with unknown encodings, like Latin-62, or other
-  # nonsense that gets put in there by spammers and weirdos
-  # -- rjbs, 2014-12-04
-  local $@;
-  my $new;
-  $$str_ref = $new
-    if eval { $new = Encode::decode("MIME-Header", $$str_ref); 1 };
+  my ($name, $str_ref) = @_;
+  $$str_ref = Email::MIME::Encode::maybe_mime_decode_header($name, $$str_ref);
   return;
 }
 


### PR DESCRIPTION
Some of headers are already marked as non-MIME and they are never
MIME-encoded. Use same logic when decoding and do not try to decode them.