### PR TITLE
Fix as_string returning unicode

### DIFF
--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -256,9 +256,13 @@ sub create {
 
 sub as_string {
   my $self = shift;
-  return $self->__head->as_string
+  my $str = $self->__head->as_string
     . ($self->{mycrlf} || "\n")  # XXX: replace with ->crlf
     . $self->body_raw;
+  if (utf8::is_utf8($str)) {
+    utf8::encode($str);
+  }
+  return $str
 }
 
 sub parts {


### PR DESCRIPTION
When msgconvert assembled the email, I found the html message part to be corrupted, having the utf8 characters replaced by utf8-reencoded bytes.
I found that parts_add will append the $part->as_string to $body. When the first part is a unicode text/plain body, the subsequent text/html (8bit encoded) part will be implicitely converted to unicode as well, which is wrong.

as_string should always return a string, never unicode. The PR fixes this.