### PR TITLE
Finish object representation of the header value and provides Email::MIME::Header::AddressList

### DIFF
--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -61,7 +61,11 @@ by all means keep reading.
   );
 
   my $email = Email::MIME->create(
-      header_str => [ From => 'casey@geeknest.com' ],
+      header_str => [
+          From => 'casey@geeknest.com',
+          To => [ 'user1@host.com', 'Name <user2@host.com>' ],
+          Cc => Email::Address::XS->new("Display Name \N{U+1F600}", 'user@example.com'),
+      ],
       parts      => [ @parts ],
   );
 
@@ -145,9 +149,17 @@ be a text string that will be MIME-encoded as needed.  Alternatively it can be
 an object with C<as_mime_string> method which implements conversion of that
 object to MIME-encoded string.  That object method is called with two input
 parameters: charset and length of header name and should return MIME-encoded
-representation of the object.  A similar C<header>
-parameter can be provided in addition to or instead of C<header_str>.  Its
-values will be used verbatim.
+representation of the object.
+
+In case header name is registered in C<%Email::MIME::Header::header_to_class_map>
+hash then registered class is used for conversion from Unicode string to 8bit
+MIME encoding.  Value can be either string or array reference to strings.
+Object is constructed via method C<from_string> with string value (or values
+in case of array reference) and converted to MIME-encoded string via
+C<as_mime_string> method.
+
+A similar C<header> parameter can be provided in addition to or instead of
+C<header_str>.  Its values will be used verbatim.
 
 C<attributes> is a hash of MIME attributes to assign to the part, and may
 override portions of the header set in the C<header> parameter.

--- a/lib/Email/MIME/Encode.pm
+++ b/lib/Email/MIME/Encode.pm
@@ -24,7 +24,7 @@ sub maybe_mime_encode_header {
     my $min_wrap_length = 78 - $header_length + 1;
 
     return $val
-        unless _needs_encode($val) || $val =~ /[^\s]{$min_wrap_length,}/;
+        unless needs_mime_encode($val) || $val =~ /[^\s]{$min_wrap_length,}/;
 
     $header =~ s/^resent-//i;
 
@@ -37,14 +37,14 @@ sub maybe_mime_encode_header {
     return mime_encode($val, $charset, $header_length);
 }
 
-sub _needs_encode {
+sub needs_mime_encode {
     my ($val) = @_;
     return defined $val && $val =~ /(?:\P{ASCII}|=\?|[^\s]{79,}|^\s+|\s+$)/s;
 }
 
-sub _needs_encode_addr {
+sub needs_mime_encode_addr {
     my ($val) = @_;
-    return _needs_encode($val) || ( defined $val && $val =~ /[:;,]/ );
+    return needs_mime_encode($val) || ( defined $val && $val =~ /[:;,]/ );
 }
 
 sub _address_list_encode {
@@ -56,10 +56,10 @@ sub _address_list_encode {
         # try to not split phrase into more encoded words (hence 0 for header_length)
         # rather fold header around mime encoded word
         $_->phrase(mime_encode($phrase, $charset, 0))
-            if _needs_encode_addr($phrase);
+            if needs_mime_encode_addr($phrase);
         my $comment = $_->comment;
         $_->comment(mime_encode($comment, $charset, 0))
-            if _needs_encode_addr($comment);
+            if needs_mime_encode_addr($comment);
     }
 
     return join(', ', map { $_->format } @addrs);

--- a/lib/Email/MIME/Encode.pm
+++ b/lib/Email/MIME/Encode.pm
@@ -71,6 +71,7 @@ sub mime_encode {
     my ($text, $charset, $header_length) = @_;
 
     $header_length = 0 unless defined $header_length;
+    $charset = 'UTF-8' unless defined $charset;
 
     my $enc_obj = Encode::find_encoding($charset);
 

--- a/lib/Email/MIME/Header.pm
+++ b/lib/Email/MIME/Header.pm
@@ -13,6 +13,14 @@ our @CARP_NOT;
 
 our %header_to_class_map;
 
+{
+  my @address_list_headers = qw(from sender reply-to to cc bcc);
+  push @address_list_headers, map { "resent-$_" } @address_list_headers;
+  push @address_list_headers, map { "downgraded-$_" } @address_list_headers; # RFC 5504
+  push @address_list_headers, qw(original-from disposition-notification-to); # RFC 5703 and RFC 3798
+  $header_to_class_map{$_} = 'Email::MIME::Header::AddressList' foreach @address_list_headers;
+}
+
 =head1 DESCRIPTION
 
 This object behaves like a standard Email::Simple header, with the following

--- a/lib/Email/MIME/Header.pm
+++ b/lib/Email/MIME/Header.pm
@@ -8,6 +8,7 @@ use parent 'Email::Simple::Header';
 use Carp ();
 use Email::MIME::Encode;
 use Encode 1.9801;
+use Module::Runtime ();
 
 our @CARP_NOT;
 
@@ -95,7 +96,9 @@ sub header_as_obj {
 
   {
     local @CARP_NOT = qw(Email::MIME);
+    local $@;
     Carp::croak("No class for header '$name' was specified") unless defined $class;
+    Carp::croak("Cannot load package '$class' for header '$name': $@") unless eval { Module::Runtime::require_module($class) };
     Carp::croak("Class '$class' does not have method 'from_mime_string'") unless $class->can('from_mime_string');
   }
 

--- a/lib/Email/MIME/Header/AddressList.pm
+++ b/lib/Email/MIME/Header/AddressList.pm
@@ -1,0 +1,321 @@
+# Copyright (c) 2016-2017 by Pali <pali@cpan.org>
+
+package Email::MIME::Header::AddressList;
+
+use strict;
+use warnings;
+
+use Carp ();
+use Email::Address::XS;
+use Email::MIME::Encode;
+
+=encoding utf8
+
+=head1 NAME
+
+Email::MIME::Header::AddressList - MIME support for list of Email::Address::XS objects
+
+=head1 SYNOPSIS
+
+  my $address1 = Email::Address::XS->new('Name1' => 'address1@host.com');
+  my $address2 = Email::Address::XS->new("Name2 \N{U+263A}" => 'address2@host.com');
+  my $mime_address = Email::Address::XS->new('=?UTF-8?B?TmFtZTIg4pi6?=' => 'address2@host.com');
+
+  my $list1 = Email::MIME::Header::AddressList->new($address1, $address2);
+
+  $list1->append_groups('undisclosed-recipients' => []);
+
+  $list1->first_address();
+  # returns $address1
+
+  $list1->groups();
+  # returns (undef, [ $address1, $address2 ], 'undisclosed-recipients', [])
+
+  $list1->as_string();
+  # returns 'Name1 <address1@host.com>, "Name2 ☺" <address2@host.com>, undisclosed-recipients:;'
+
+  $list1->as_mime_string();
+  # returns 'Name1 <address1@host.com>, =?UTF-8?B?TmFtZTIg4pi6?= <address2@host.com>, undisclosed-recipients:;'
+
+  my $list2 = Email::MIME::Header::AddressList->new_groups(Group => [ $address1, $address2 ]);
+
+  $list2->append_addresses($address2);
+
+  $list2->addresses();
+  # returns ($address2, $address1, $address2)
+
+  $list2->groups();
+  # returns (undef, [ $address2 ], 'Group', [ $address1, $address2 ])
+
+  my $list3 = Email::MIME::Header::AddressList->new_mime_groups('=?UTF-8?B?4pi6?=' => [ $mime_address ]);
+  $list3->as_string();
+  # returns '☺: "Name2 ☺" <address2@host.com>;'
+
+  my $list4 = Email::MIME::Header::AddressList->from_string('Name1 <address1@host.com>, "Name2 ☺" <address2@host.com>, undisclosed-recipients:;');
+  my $list5 = Email::MIME::Header::AddressList->from_string('Name1 <address1@host.com>', '"Name2 ☺" <address2@host.com>', 'undisclosed-recipients:;');
+
+  my $list6 = Email::MIME::Header::AddressList->from_mime_string('Name1 <address1@host.com>, =?UTF-8?B?TmFtZTIg4pi6?= <address2@host.com>, undisclosed-recipients:;');
+  my $list7 = Email::MIME::Header::AddressList->from_mime_string('Name1 <address1@host.com>', '=?UTF-8?B?TmFtZTIg4pi6?= <address2@host.com>', 'undisclosed-recipients:;');
+
+=head1 DESCRIPTION
+
+This module implements object representation for the list of the
+L<Email::Address::XS|Email::Address::XS> objects. It provides methods for
+L<RFC 2047|https://tools.ietf.org/html/rfc2047> MIME encoding and decoding
+suitable for L<RFC 2822|https://tools.ietf.org/html/rfc2822> address-list
+structure.
+
+=head2 EXPORT
+
+None
+
+=head2 Class Methods
+
+=over 4
+
+=item new_empty
+
+Construct new empty C<Email::MIME::Header::AddressList> object.
+
+=cut
+
+sub new_empty {
+  my ($class) = @_;
+  return bless { addresses => [], groups => [] }, $class;
+}
+
+=item new
+
+Construct new C<Email::MIME::Header::AddressList> object from list of
+L<Email::Address::XS|Email::Address::XS> objects.
+
+=cut
+
+sub new {
+  my ($class, @addresses) = @_;
+  my $self = $class->new_empty();
+  $self->append_addresses(@addresses);
+  return $self;
+}
+
+=item new_groups
+
+Construct new C<Email::MIME::Header::AddressList> object from named groups of
+L<Email::Address::XS|Email::Address::XS> objects.
+
+=cut
+
+sub new_groups {
+  my ($class, @groups) = @_;
+  my $self = $class->new_empty();
+  $self->append_groups(@groups);
+  return $self;
+}
+
+=item new_mime_groups
+
+Like L<C<new_groups>|/new_groups> but in this method group names and objects properties are
+expected to be already MIME encoded, thus ASCII strings.
+
+=cut
+
+sub new_mime_groups {
+  my ($class, @groups) = @_;
+  if (scalar @groups % 2) {
+    Carp::carp 'Odd number of elements in argument list';
+    return;
+  }
+  foreach (0 .. scalar @groups / 2 - 1) {
+    $groups[2 * $_] = Email::MIME::Encode::mime_decode($groups[2 * $_])
+      if defined $groups[2 * $_] and $groups[2 * $_] =~ /=\?/;
+    $groups[2 * $_ + 1] = [ @{$groups[2 * $_ + 1]} ];
+    foreach (@{$groups[2 * $_ + 1]}) {
+      next unless Email::Address::XS->is_obj($_);
+      my $decode_phrase = defined $_->phrase and $_->phrase =~ /=\?/;
+      my $decode_comment = defined $_->comment and $_->comment =~ /=\?/;
+      next unless $decode_phrase or $decode_comment;
+      $_ = ref($_)->new(copy => $_);
+      $_->phrase(Email::MIME::Encode::mime_decode($_->phrase))
+        if $decode_phrase;
+      $_->comment(Email::MIME::Encode::mime_decode($_->comment))
+        if $decode_comment;
+    }
+  }
+  return $class->new_groups(@groups);
+}
+
+=item from_string
+
+Construct new C<Email::MIME::Header::AddressList> object from input string arguments.
+Calls L<Email::Address::XS::parse_email_groups|Email::Address::XS/parse_email_groups>.
+
+=cut
+
+sub from_string {
+  my ($class, @strings) = @_;
+  return $class->new_groups(map { Email::Address::XS::parse_email_groups($_) } @strings);
+}
+
+=item from_mime_string
+
+Like L<C<from_string>|/from_string> but input string arguments are expected to
+be already MIME encoded.
+
+=cut
+
+sub from_mime_string {
+  my ($class, @strings) = @_;
+  return $class->new_mime_groups(map { Email::Address::XS::parse_email_groups($_) } @strings);
+}
+
+=back
+
+=head2 Object Methods
+
+=over 4
+
+=item as_string
+
+Returns string representation of C<Email::MIME::Header::AddressList> object.
+Calls L<Email::Address::XS::format_email_groups|Email::Address::XS/format_email_groups>.
+
+=cut
+
+sub as_string {
+  my ($self) = @_;
+  return Email::Address::XS::format_email_groups($self->groups());
+}
+
+=item as_mime_string
+
+Like L<C<as_string>|/as_string> but output string will be properly and
+unambiguously MIME encoded. MIME encoding is done before calling
+L<Email::Address::XS::format_email_groups|Email::Address::XS/format_email_groups>.
+
+=cut
+
+sub as_mime_string {
+  my ($self, $charset, $header_length) = @_;
+  my @groups = $self->groups();
+  foreach (0 .. scalar @groups / 2 - 1) {
+    $groups[2 * $_] = Email::MIME::Encode::mime_encode($groups[2 * $_], $charset)
+      if Email::MIME::Encode::needs_mime_encode_addr($groups[2 * $_]);
+    $groups[2 * $_ + 1] = [ @{$groups[2 * $_ + 1]} ];
+    foreach (@{$groups[2 * $_ + 1]}) {
+      my $encode_phrase = Email::MIME::Encode::needs_mime_encode_addr($_->phrase);
+      my $encode_comment = Email::MIME::Encode::needs_mime_encode_addr($_->comment);
+      next unless $encode_phrase or $encode_comment;
+      $_ = ref($_)->new(copy => $_);
+      $_->phrase(Email::MIME::Encode::mime_encode($_->phrase, $charset))
+        if $encode_phrase;
+      $_->comment(Email::MIME::Encode::mime_encode($_->comment, $charset))
+        if $encode_comment;
+    }
+  }
+  return Email::Address::XS::format_email_groups(@groups);
+}
+
+=item first_address
+
+Returns first L<Email::Address::XS|Email::Address::XS> object.
+
+=cut
+
+sub first_address {
+  my ($self) = @_;
+  return $self->{addresses}->[0] if @{$self->{addresses}};
+  my $groups = $self->{groups};
+  foreach (0 .. @{$groups} / 2 - 1) {
+    next unless @{$groups->[2 * $_ + 1]};
+    return $groups->[2 * $_ + 1]->[0];
+  }
+  return undef;
+}
+
+=item addresses
+
+Returns list of all L<Email::Address::XS|Email::Address::XS> objects.
+
+=cut
+
+sub addresses {
+  my ($self) = @_;
+  my $t = 1;
+  my @addresses = @{$self->{addresses}};
+  push @addresses, map { @{$_} } grep { $t ^= 1 } @{$self->{groups}};
+  return @addresses;
+}
+
+=item groups
+
+Like L<C<addresses>|/addresses> but returns objects with named groups.
+
+=cut
+
+sub groups {
+  my ($self) = @_;
+  my @groups = @{$self->{groups}};
+  $groups[2 * $_ + 1] = [ @{$groups[2 * $_ + 1]} ]
+    foreach 0 .. scalar @groups / 2 - 1;
+  unshift @groups, undef, [ @{$self->{addresses}} ]
+    if @{$self->{addresses}};
+  return @groups;
+}
+
+=item append_addresses
+
+Append L<Email::Address::XS|Email::Address::XS> objects.
+
+=cut
+
+sub append_addresses {
+  my ($self, @addresses) = @_;
+  my @valid_addresses = grep { Email::Address::XS->is_obj($_) } @addresses;
+  Carp::carp 'Argument is not an Email::Address::XS object' if scalar @valid_addresses != scalar @addresses;
+  push @{$self->{addresses}}, @valid_addresses;
+}
+
+=item append_groups
+
+Like L<C<append_addresses>|/append_addresses> but arguments are pairs of name of
+group and array reference of L<Email::Address::XS|Email::Address::XS> objects.
+
+=cut
+
+sub append_groups {
+  my ($self, @groups) = @_;
+  if (scalar @groups % 2) {
+    Carp::carp 'Odd number of elements in argument list';
+    return;
+  }
+  my $carp_invalid = 1;
+  my @valid_groups;
+  foreach (0 .. scalar @groups / 2 - 1) {
+    push @valid_groups, $groups[2 * $_];
+    my $addresses = $groups[2 * $_ + 1];
+    my @valid_addresses = grep { Email::Address::XS->is_obj($_) } @{$addresses};
+    if ($carp_invalid and scalar @valid_addresses != scalar @{$addresses}) {
+      Carp::carp 'Array element is not an Email::Address::XS object';
+      $carp_invalid = 0;
+    }
+    push @valid_groups, \@valid_addresses;
+  }
+  push @{$self->{groups}}, @valid_groups;
+}
+
+=back
+
+=head1 SEE ALSO
+
+L<RFC 2047|https://tools.ietf.org/html/rfc2047>,
+L<RFC 2822|https://tools.ietf.org/html/rfc2822>,
+L<Email::MIME>,
+L<Email::Address::XS>
+
+=head1 AUTHOR
+
+Pali E<lt>pali@cpan.orgE<gt>
+
+=cut
+
+1;

--- a/t/charset.t
+++ b/t/charset.t
@@ -5,7 +5,7 @@ use Test::More;
 use Email::MIME;
 
 my $email = Email::MIME->create(
-  header_str => [
+  header    => [
     From    => q{"Your name" <your_email@some-domain.com>},
     To      => q{"The recipients's name" <recipients_email@some-domain.com>},
     Subject => q{Lorem ipsum dolor}

--- a/t/header-addresslist.t
+++ b/t/header-addresslist.t
@@ -1,0 +1,142 @@
+use strict;
+use warnings;
+use Test::More;
+use Encode;
+
+BEGIN {
+  plan skip_all => 'Email::Address::XS is required for this test' unless eval { require Email::Address::XS };
+  plan 'no_plan';
+}
+
+BEGIN {
+  use_ok('Email::MIME');
+  use_ok('Email::MIME::Header::AddressList');
+}
+
+{
+  my $email = Email::MIME->new('To: =?US-ASCII?Q?MIME=3A=3B?=: =?US-ASCII?Q?Winston=3A_Smith?= <winston.smith@recdep.minitrue>, =?US-ASCII?Q?Julia=3A=3B_?= <julia@ficdep.minitrue>' . "\r\n\r\n");
+  my $str = $email->header_str('To');
+  my $obj = $email->header_as_obj('To');
+  my @addr = $obj->addresses();
+  my @grps = $obj->groups();
+  is($str, '"MIME:;": "Winston: Smith" <winston.smith@recdep.minitrue>, "Julia:; " <julia@ficdep.minitrue>;'); # See that decoded From header string is now quoted, so is unambiguous
+  is($addr[0]->phrase, 'Winston: Smith');
+  is($addr[0]->address, 'winston.smith@recdep.minitrue');
+  is($addr[1]->phrase, 'Julia:; ');
+  is($addr[1]->address, 'julia@ficdep.minitrue');
+  is($grps[0], 'MIME:;');
+  is($grps[1]->[0]->phrase, 'Winston: Smith');
+  is($grps[1]->[0]->address, 'winston.smith@recdep.minitrue');
+  is($grps[1]->[1]->phrase, 'Julia:; ');
+  is($grps[1]->[1]->address, 'julia@ficdep.minitrue');
+}
+
+{
+  my $julia = Email::Address::XS->new(phrase => 'Julia:; ', address => 'julia@ficdep.minitrue');
+  my $winston = Email::Address::XS->new(phrase => 'Winston:; Smith', address => 'winston.smith@recdep.minitrue');
+  my $email = Email::MIME->create(
+    header_str => [
+      Sender => $julia,
+      From => [ $winston, $julia ],
+      To => Email::MIME::Header::AddressList->new_groups('Group:;Name' => [ $julia, $winston ]),
+    ]
+  );
+  my $sender_header_raw = $email->header_raw('Sender');
+  my $from_header_raw = $email->header_raw('From');
+  my $to_header_raw = $email->header_raw('To');
+  my $sender_header = $email->header_str('Sender');
+  my $from_header = $email->header_str('From');
+  my $to_header = $email->header_str('To');
+  my $sender_addr = $email->header_as_obj('Sender')->first_address();
+  my @from_addrs = $email->header_as_obj('From')->addresses();
+  my @to_grps = $email->header_as_obj('To')->groups();
+  is($sender_header_raw, '=?UTF-8?B?SnVsaWE6OyA=?= <julia@ficdep.minitrue>');
+  is($from_header_raw, '=?UTF-8?B?V2luc3Rvbjo7IFNtaXRo?= <winston.smith@recdep.minitrue>, =?UTF-8?B?SnVsaWE6OyA=?= <julia@ficdep.minitrue>');
+  is($to_header_raw, '=?UTF-8?B?R3JvdXA6O05hbWU=?=: =?UTF-8?B?SnVsaWE6OyA=?= <julia@ficdep.minitrue>, =?UTF-8?B?V2luc3Rvbjo7IFNtaXRo?= <winston.smith@recdep.minitrue>;');
+  is($sender_header, '"Julia:; " <julia@ficdep.minitrue>');
+  is($from_header, '"Winston:; Smith" <winston.smith@recdep.minitrue>, "Julia:; " <julia@ficdep.minitrue>');
+  is($to_header, '"Group:;Name": "Julia:; " <julia@ficdep.minitrue>, "Winston:; Smith" <winston.smith@recdep.minitrue>;');
+  is($sender_addr->phrase, 'Julia:; ');
+  is($from_addrs[0]->phrase, 'Winston:; Smith');
+  is($from_addrs[1]->phrase, 'Julia:; ');
+  is($to_grps[0], 'Group:;Name');
+  is($to_grps[1]->[0]->phrase, 'Julia:; ');
+  is($to_grps[1]->[1]->phrase, 'Winston:; Smith');
+
+  $email->header_raw_set('Sender', 'Julia <julia@ficdep.minitrue>');
+  $sender_header_raw = $email->header_raw('Sender');
+  $sender_header = $email->header_str('Sender');
+  $sender_addr = $email->header_as_obj('Sender')->first_address();
+  is($sender_header_raw, 'Julia <julia@ficdep.minitrue>');
+  is($sender_header, 'Julia <julia@ficdep.minitrue>');
+  is($sender_addr->phrase, 'Julia');
+  is($sender_addr->address, 'julia@ficdep.minitrue');
+
+  $email->header_raw_set('Bcc', '=?UTF-8?B?SnVsaWE6OyA=?= <julia@ficdep.minitrue>');
+  my $bcc_header_raw = $email->header_raw('Bcc');
+  my $bcc_header = $email->header_str('Bcc');
+  my $bcc_addr = $email->header_as_obj('Bcc')->first_address();
+  my @bcc_grps = $email->header_as_obj('Bcc')->groups();
+  is($bcc_header_raw, '=?UTF-8?B?SnVsaWE6OyA=?= <julia@ficdep.minitrue>');
+  is($bcc_header, '"Julia:; " <julia@ficdep.minitrue>');
+  is($bcc_addr->phrase, 'Julia:; ');
+  is($bcc_addr->address, 'julia@ficdep.minitrue');
+  is($bcc_grps[0], undef);
+  is($bcc_grps[1]->[0]->phrase, 'Julia:; ');
+  is($bcc_grps[1]->[0]->address, 'julia@ficdep.minitrue');
+
+  # Explicit call with object Email::MIME::Header::AddressList
+  $email->header_str_set('Bcc', Email::MIME::Header::AddressList->new_groups('Group' => [ $winston ]));
+  $bcc_header_raw = $email->header_raw('Bcc');
+  $bcc_header = $email->header_str('Bcc');
+  $bcc_addr = $email->header_as_obj('Bcc')->first_address();
+  @bcc_grps = $email->header_as_obj('Bcc')->groups();
+  is($bcc_header_raw, 'Group: =?UTF-8?B?V2luc3Rvbjo7IFNtaXRo?= <winston.smith@recdep.minitrue>;');
+  is($bcc_header, 'Group: "Winston:; Smith" <winston.smith@recdep.minitrue>;');
+  is($bcc_addr->phrase, 'Winston:; Smith');
+  is($bcc_addr->address, 'winston.smith@recdep.minitrue');
+  is($bcc_grps[0], 'Group');
+  is($bcc_grps[0], 'Group');
+  is($bcc_grps[1]->[0]->phrase, 'Winston:; Smith');
+  is($bcc_grps[1]->[0]->address, 'winston.smith@recdep.minitrue');
+
+  # Implicit call to Email::MIME::Header::AddressList->from_string($string)
+  $email->header_str_set('Cc', '"MIME:;": "Winston: Smith" <winston.smith@recdep.minitrue>;');
+  my $cc_header_raw = $email->header_raw('Cc');
+  my $cc_header = $email->header_str('Cc');
+  my $cc_addr = $email->header_as_obj('Cc')->first_address();
+  my @cc_grps = $email->header_as_obj('Cc')->groups();
+  is($cc_header_raw, '=?UTF-8?B?TUlNRTo7?=: =?UTF-8?B?V2luc3RvbjogU21pdGg=?= <winston.smith@recdep.minitrue>;');
+  is($cc_header, '"MIME:;": "Winston: Smith" <winston.smith@recdep.minitrue>;');
+  is($cc_addr->phrase, 'Winston: Smith');
+  is($cc_addr->address, 'winston.smith@recdep.minitrue');
+  is($cc_grps[0], 'MIME:;');
+  is($cc_grps[1]->[0]->phrase, 'Winston: Smith');
+  is($cc_grps[1]->[0]->address, 'winston.smith@recdep.minitrue');
+
+  # Implicit stringification of $winston and call to Email::MIME::Header::AddressList->from_string($string)
+  $email->header_str_set('Sender', $winston);
+  $sender_header_raw = $email->header_raw('Sender');
+  $sender_header = $email->header_str('Sender');
+  $sender_addr = $email->header_as_obj('Sender')->first_address();
+  is($sender_header_raw, '=?UTF-8?B?V2luc3Rvbjo7IFNtaXRo?= <winston.smith@recdep.minitrue>');
+  is($sender_header, '"Winston:; Smith" <winston.smith@recdep.minitrue>');
+  is($sender_addr->phrase, 'Winston:; Smith');
+  is($sender_addr->address, 'winston.smith@recdep.minitrue');
+
+  # Implicit stringification of $winston and $julia and call to Email::MIME::Header::AddressList->from_string($winston, $julia)
+  $email->header_str_set('Cc', [ $winston, $julia ]);
+  $cc_header_raw = $email->header_raw('Cc');
+  $cc_header = $email->header_str('Cc');
+  $cc_addr = $email->header_as_obj('Cc')->first_address();
+  @cc_grps = $email->header_as_obj('Cc')->groups();
+  is($cc_header_raw, '=?UTF-8?B?V2luc3Rvbjo7IFNtaXRo?= <winston.smith@recdep.minitrue>, =?UTF-8?B?SnVsaWE6OyA=?= <julia@ficdep.minitrue>');
+  is($cc_header, '"Winston:; Smith" <winston.smith@recdep.minitrue>, "Julia:; " <julia@ficdep.minitrue>');
+  is($cc_addr->phrase, 'Winston:; Smith');
+  is($cc_addr->address, 'winston.smith@recdep.minitrue');
+  is($cc_grps[0], undef);
+  is($cc_grps[1]->[0]->phrase, 'Winston:; Smith');
+  is($cc_grps[1]->[0]->address, 'winston.smith@recdep.minitrue');
+  is($cc_grps[1]->[1]->phrase, 'Julia:; ');
+  is($cc_grps[1]->[1]->address, 'julia@ficdep.minitrue');
+}

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -60,7 +60,8 @@ require_ok 'Email::MIME::Creator';
   );
 }
 
-{
+SKIP: {
+  skip 'Email::Address::XS is required for this test', 1 unless eval { require Email::Address::XS };
   my @subjects = (
     "test test test test test test test test tést te (12 34)", # unicode
     "test test test test test test test test test te (12 34)", # not

--- a/t/unicode.t
+++ b/t/unicode.t
@@ -69,6 +69,8 @@ require_ok 'Email::MIME::Creator';
   my @tos = (
     'Döy <test@example.com>', # unicode
     'Doy <test@example.com>', # not
+    '"<look@like.address>," <test@example.com>', # address-like pattern in phrase
+    '"Döy <look@like.address>," <test@example.com>', # unicode address-like pattern in phrase
   );
 
   for my $subject (@subjects) {
@@ -82,7 +84,13 @@ require_ok 'Email::MIME::Creator';
       );
       is(scalar($email->header('Subject')), $subject,
          "Subject header is correct");
+      $email->header_str_set('Subject', $subject);
+      is(scalar($email->header_str('Subject')), $subject,
+         "Subject header is correct");
       is(scalar($email->header('To')), $to,
+         "To header is correct");
+      $email->header_str_set('To', $to);
+      is(scalar($email->header_str('To')), $to,
          "To header is correct");
       like($email->as_string, qr/test\@example\.com/,
            "address isn't encoded");


### PR DESCRIPTION
This pull request now contains all remaining commits related to object representation of header value and implemented proper parsing of address-list header according to RFC2047 & RFC2822 via new module Email::MIME::Header::AddressList (which uses Email::Address::XS).

Feel free to comment changes or propose some improvements. Specially documentation for Email::MIME::Header::AddressList could be better, but I'm not native English speaker...