### PR TITLE
Use function parse_content_disposition from Email::MIME::ContentType

### DIFF
--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -18,6 +18,8 @@ use Email::MIME::Modifier;
 use Encode 1.9801 ();
 use Scalar::Util qw(reftype weaken);
 
+our @CARP_NOT = qw(Email::MIME::ContentType);
+
 =head1 SYNOPSIS
 
 B<Wait!>  Before you read this, maybe you just need L<Email::Stuffer>, which is


### PR DESCRIPTION
Currently Email::MIME uses private function _parse_attributes from the
Email::MIME::ContentType module for parsing Content-Disposition header
which is bad thing. New version of Email::MIME::ContentType module has
parse_content_disposition function for this purpose.

Stop using private functions of other modules!

___

Depends on releasing new version of Email::MIME::ContentType with this patch:
https://github.com/rjbs/Email-MIME-ContentType/pull/8