### PR TITLE
Subparts should inherit email's encode_check

### DIFF
--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -410,7 +410,7 @@ sub parts_multipart {
   for my $bit (@bits) {
     $bit =~ s/\A[\n\r]+//smg;
     $bit =~ s/(?<!\x0d)$self->{mycrlf}\Z//sm;
-    my $email = (ref $self)->new($bit);
+    my $email = (ref $self)->new($bit, { encode_check => $self->encode_check });
     push @parts, $email;
   }
 
@@ -580,7 +580,7 @@ sub content_type_attribute_set {
 
 =method encode_check
 
-=method encode_check-set
+=method encode_check_set
 
   $email->encode_check;
   $email->encode_check_set(0);

--- a/t/encode-check.t
+++ b/t/encode-check.t
@@ -32,6 +32,31 @@ subtest "encode_check 0 during create()" => sub {
   );
 };
 
+subtest "encode_check 0 during create(), multi-part" => sub {
+  my $email = Email::MIME->create(
+    parts => [
+        q[Totally ascii first part],
+        q[Look, a snowman: ☃],
+    ],
+    encode_check => Encode::FB_DEFAULT,
+  );
+
+  ok($email, 'we created an email with badly encoded data');
+
+  my $part_num = 1;
+
+  $email->walk_parts(sub {
+    my ($part) = @_;
+    return if $part->subparts;
+
+    is(
+      $part->encode_check,
+      Encode::FB_DEFAULT,
+      "subpart picked up email's encode_check setting"
+    );
+  });
+};
+
 subtest "encode_check 0 during new()" => sub {
   my $email = Email::MIME->new(<<'EOF', { encode_check => 0 });
 Date: Fri, 16 Jun 2017 09:48:19 -0400


### PR DESCRIPTION
Each subpart is created with $self->new(), and the code that did this
wasn't passing through its own encode_check value. This meant that
multipart emails created with non-default values for encode_check
weren't really getting them, since every subpart falls back to
Email::MIME's default of Encode::FB_CROAK.