### PR TITLE
Use functions build_content_disposition and build_content_type from Email::MIME::ContentType

### DIFF
--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -10,7 +10,7 @@ use parent qw(Email::Simple);
 use Carp ();
 use Email::MessageID;
 use Email::MIME::Creator;
-use Email::MIME::ContentType 1.022; # parse_content_disposition
+use Email::MIME::ContentType 1.023; # build_content_type
 use Email::MIME::Encode;
 use Email::MIME::Encodings 1.314;
 use Email::MIME::Header;
@@ -727,20 +727,14 @@ header information is preserved when setting this attribute.
 sub filename_set {
   my ($self, $filename) = @_;
   my $dis_header = $self->header('Content-Disposition');
-  my ($disposition, $attrs);
+  my ($disposition, $attrs) = ('inline', {});
   if ($dis_header) {
     my $struct = parse_content_disposition($dis_header);
     $disposition = $struct->{type};
     $attrs = $struct->{attributes};
   }
   $filename ? $attrs->{filename} = $filename : delete $attrs->{filename};
-  $disposition ||= 'inline';
-
-  my $dis = $disposition;
-  while (my ($attr, $val) = each %{$attrs}) {
-    $dis .= qq[; $attr="$val"];
-  }
-
+  my $dis = build_content_disposition({type => $disposition, attributes => $attrs});
   $self->header_raw_set('Content-Disposition' => $dis);
 }
 
@@ -885,11 +879,7 @@ sub walk_parts {
 
 sub _compose_content_type {
   my ($self, $ct_header) = @_;
-  my $ct = join q{/}, @{$ct_header}{qw[type subtype]};
-  for my $attr (sort keys %{ $ct_header->{attributes} }) {
-    next unless defined (my $value = $ct_header->{attributes}{$attr});
-    $ct .= qq[; $attr="$value"];
-  }
+  my $ct = build_content_type({type => $ct_header->{type}, subtype => $ct_header->{subtype}, attributes => $ct_header->{attributes}});
   $self->header_raw_set('Content-Type' => $ct);
   $self->{ct} = $ct_header;
 }

--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -787,7 +787,11 @@ sub parts_set {
     my $from_ct = parse_content_type($parts->[0]->header('Content-Type'));
     @{$ct_header}{qw[type subtype]} = @{ $from_ct }{qw[type subtype]};
 
-    $ct_header->{attributes}{charset} = $from_ct->{attributes}{charset};
+    if (exists $from_ct->{attributes}{charset}) {
+      $ct_header->{attributes}{charset} = $from_ct->{attributes}{charset};
+    } else {
+      delete $ct_header->{attributes}{charset};
+    }
 
     $self->encoding_set($parts->[0]->header('Content-Transfer-Encoding'));
     delete $ct_header->{attributes}->{boundary};

--- a/t/body-ref.t
+++ b/t/body-ref.t
@@ -27,7 +27,7 @@ for my $ref (0,1) {
 
     isnt(index($email->body, 'I LIKE PIE'), -1, "$prefix: target string");
 
-    like($email->header('Content-Type'), qr/invented="xyzzy"/, "custom CT param");
+    like($email->header('Content-Type'), qr/invented=(?:"xyzzy"|xyzzy)/, "custom CT param");
   };
 }
 

--- a/t/ct_attrs.t
+++ b/t/ct_attrs.t
@@ -63,8 +63,8 @@ is_deeply( parse_content_type($email->header('Content-Type')), {
     },
 }, 'ct with name worked' );
 
-is $email->header('Content-Type'),
-    'text/plain; format="flowed"; name="foo.txt"',
+like $email->header('Content-Type'),
+    qr'^text/plain; format=(?:"flowed"|flowed); name=(?:"foo\.txt"|foo\.txt)$',
     'ct format is correct';
 
 $email->boundary_set( 'marker' );
@@ -80,8 +80,8 @@ is_deeply( parse_content_type($email->header('Content-Type')), {
 
 $email->content_type_attribute_set( 'Bananas' => 'true' );
 
-is $email->header('Content-Type'),
-    'text/plain; bananas="true"; boundary="marker"; format="flowed"; name="foo.txt"',
+like $email->header('Content-Type'),
+    qr'^text/plain; bananas=(?:"true"|true); boundary=(?:"marker"|marker); format=(?:"flowed"|flowed); name=(?:"foo\.txt"|foo\.txt)$',
     'ct format is correct';
 
 is_deeply( parse_content_type($email->header('Content-Type')), {

--- a/t/disposition.t
+++ b/t/disposition.t
@@ -20,11 +20,11 @@ is $email->header('Content-Disposition'), 'attachment', 'reset worked';
 
 $email->filename_set( 'loco.pdf' );
 
-is $email->header('Content-Disposition'), 'attachment; filename="loco.pdf"', 'filename_set worked';
+like $email->header('Content-Disposition'), qr'^attachment; filename=(?:"loco\.pdf"|loco\.pdf)$', 'filename_set worked';
 
 $email->disposition_set('inline');
 
-is $email->header('Content-Disposition'), 'inline; filename="loco.pdf"', 're-reset worked';
+like $email->header('Content-Disposition'), qr'^inline; filename=(?:"loco\.pdf"|loco\.pdf)$', 're-reset worked';
 
 $email->filename_set(undef);
 

--- a/t/disposition.t
+++ b/t/disposition.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
-use Test::More tests => 7;
+use utf8;
+use Test::More tests => 9;
 
 use_ok 'Email::MIME';
 use_ok 'Email::MIME::Modifier';
@@ -30,3 +31,10 @@ $email->filename_set(undef);
 
 is $email->header('Content-Disposition'), 'inline', 'filename_set(undef) worked';
 
+$email->disposition_set('attachment');
+
+$email->filename_set('hah"ha"\'ha\\');
+is $email->header('Content-Disposition'), q(attachment; filename="hah\\"ha\\"'ha\\\\");
+
+$email->filename_set('kůň.pdf');
+is $email->header('Content-Disposition'), q(attachment; filename*=UTF-8''k%C5%AF%C5%88.pdf; filename=kun.pdf);


### PR DESCRIPTION
New version of Email::MIME::ContentType would have functions for composing
Content-Type and Content-Disposition headers.

As a bonus they support Unicode strings encoded to UTF-8 according to
RFC 2231. Therefore Email::MIME can set Unicode file name for the
attachment.

Some tests were slightly modified as attributes do not have to be always
quoted and Email::MIME::ContentType do it only if needed.

Fixes #18
Fixes #31

Depends on https://github.com/rjbs/Email-MIME-ContentType/pull/11