### PR TITLE
Preserve original email if encoding is not required

### DIFF
--- a/lib/Email/MIME/Encode.pm
+++ b/lib/Email/MIME/Encode.pm
@@ -2,7 +2,6 @@ use strict;
 use warnings;
 package Email::MIME::Encode;
 # ABSTRACT: a private helper for MIME header encoding
-
 use Carp ();
 use Encode ();
 use MIME::Base64();
@@ -26,14 +25,14 @@ sub maybe_mime_encode_header {
       header_name_length => $header_name_length,
     });
   }
-
-  return _object_encode($val, $charset, $header_name_length, $Email::MIME::Header::header_to_class_map{$header})
-    if exists $Email::MIME::Header::header_to_class_map{$header};
-
   my $min_wrap_length = 78 - $header_name_length + 1;
 
   return $val
-    unless _needs_mime_encode($val) || $val =~ /[^\s]{$min_wrap_length,}/;
+    if !ref $val && !_needs_mime_encode_addr($val) && $val !~ /[^\s]{$min_wrap_length,}/;
+
+
+  return _object_encode($val, $charset, $header_name_length, $Email::MIME::Header::header_to_class_map{$header})
+    if exists $Email::MIME::Header::header_to_class_map{$header};
 
   return $val
     if exists $no_mime_headers{$header};

--- a/t/simple-roundtrip.t
+++ b/t/simple-roundtrip.t
@@ -1,0 +1,37 @@
+use strict;
+use warnings;
+use Test::More;
+use Encode;
+
+BEGIN {
+    plan skip_all => 'Email::Address::XS is required for this test'
+      unless eval { require Email::Address::XS };
+    plan 'no_plan';
+}
+
+BEGIN {
+    use_ok('Email::MIME::Encode');
+}
+
+ok !$INC{'Email/MIME/Header.pm'}, 'Email::MIME::Header not loaded';
+
+my @emails = ( q[<iwrestled@abear.once>], q[me@domoain.cow],
+    q["My Name" <me@domain.cow>] );
+
+foreach my $iter ( 1 .. 2 ) {
+    my $txt =
+      $iter == 1
+      ? 'Email::MIME::Header is not loaded'
+      : 'Email::MIME::Header is loaded';
+
+    foreach my $email (@emails) {
+        my $roundtrip = Email::MIME::Encode::maybe_mime_encode_header(
+            To => $email,
+            "utf-8"
+        );
+        is $roundtrip, $email, "preserve original email when $txt";
+    }
+
+    use_ok('Email::MIME::Header') if $iter == 1;
+
+}


### PR DESCRIPTION
GH #52 

Show a regression introduced by commit ed7c2907ecca5
which is using Email::Adress::XS to format the email
which result in stripping the 'angle brackets' around
an email when not using a 'phrase' for the email.

Previous behavior was preserving the '<quoted@email>'.