### PR TITLE
Fix Email::MIME::Encode::maybe_mime_encode_header to work also without explicit "use Email::MIME::Header"

### DIFF
--- a/lib/Email/MIME/Encode.pm
+++ b/lib/Email/MIME/Encode.pm
@@ -5,6 +5,7 @@ package Email::MIME::Encode;
 
 use Carp ();
 use Encode ();
+use Email::MIME::Header;
 use MIME::Base64();
 use Module::Runtime ();
 use Scalar::Util;

--- a/lib/Email/MIME/Header.pm
+++ b/lib/Email/MIME/Header.pm
@@ -14,7 +14,7 @@ our @CARP_NOT;
 
 our %header_to_class_map;
 
-{
+BEGIN {
   my @address_list_headers = qw(from sender reply-to to cc bcc);
   push @address_list_headers, map { "resent-$_" } @address_list_headers;
   push @address_list_headers, map { "downgraded-$_" } @address_list_headers; # RFC 5504

--- a/t/email-mime-encode.t
+++ b/t/email-mime-encode.t
@@ -1,0 +1,19 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+
+BEGIN {
+  plan skip_all => 'Email::Address::XS is required for this test' unless eval { require Email::Address::XS };
+  plan 'no_plan';
+}
+
+BEGIN {
+  use_ok('Email::MIME::Encode');
+}
+
+is(
+  Email::MIME::Encode::maybe_mime_encode_header('To', '"Name ☺" <user@host>'),
+  '=?UTF-8?B?TmFtZSDimLo=?= <user@host>',
+  'Email::MIME::Encode::maybe_mime_encode_header works without "use Email::MIME::Header"'
+);


### PR DESCRIPTION
Email::MIME::Encode uses %Email::MIME::Header::header_to_class_map variable
but have not loaded Email::MIME::Header module. This patch fixes it.

Problem discovered by @atoomic in report #52.