### PR TITLE
Sort hash keys to keep attributes consistent

### DIFF
--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -255,7 +255,7 @@ sub create {
 
   my $email = $class->new($header, \%pass_on);
 
-  for my $key (keys %attrs) {
+  for my $key (sort keys %attrs) {
     $email->content_type_attribute_set($key => $attrs{$key});
   }
 


### PR DESCRIPTION
Hashes in Perl are unsorted, and this can lead to inconsistent ordering. It may be even better to use an array instead of hash map to keep the order, but this is a simple solution for now.