### PR TITLE
WIP: why so slow?

### DIFF
--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -387,7 +387,8 @@ sub parts_multipart {
   # that means it's a bogus message, but a mangled result (or exception) is
   # better than endless recursion. -- rjbs, 2008-01-07
   return $self->parts_single_part
-    unless $boundary and $self->body_raw =~ /^--\Q$boundary\E\s*$/sm;
+    unless defined $boundary and length $boundary and
+           $self->body_raw =~ /^--\Q$boundary\E\s*$/sm;
 
   $self->{body_raw} = $self->SUPER::body;
 
@@ -541,7 +542,7 @@ sub boundary_set {
   my ($self, $value) = @_;
   my $ct_header = parse_content_type($self->header('Content-Type'));
 
-  if ($value) {
+  if (defined $value and length $value) {
     $ct_header->{attributes}->{boundary} = $value;
   } else {
     delete $ct_header->{attributes}->{boundary};
@@ -764,7 +765,8 @@ sub parts_set {
   if (@{$parts} > 1 or $ct_header->{type} eq 'multipart') {
 
     # setup multipart
-    $ct_header->{attributes}->{boundary} ||= Email::MessageID->new->user;
+    $ct_header->{attributes}->{boundary} = Email::MessageID->new->user
+      unless defined $ct_header->{attributes}->{boundary} and length $ct_header->{attributes}->{boundary};
     my $bound = $ct_header->{attributes}->{boundary};
     foreach my $part (@{$parts}) {
       $body .= "$self->{mycrlf}--$bound$self->{mycrlf}";

--- a/t/multipart.t
+++ b/t/multipart.t
@@ -2,8 +2,6 @@ use strict;
 use warnings;
 use Test::More;
 
-use Carp; $SIG{__WARN__} = sub { Carp::cluck @_ };
-
 use_ok 'Email::MIME::Creator';
 
 my $hi    = Email::MIME->create(body => "Hi");

--- a/t/multipart.t
+++ b/t/multipart.t
@@ -67,21 +67,28 @@ is $parts[2]->body_str, 'Hello';
 {
   my $email = Email::MIME->new(<<'END');
 Subject: hello
-Content-Type: multipart/mixed; boundary="bananas"
+Content-Type: multipart/mixed; boundary="0"
 
 Prelude
 
---bananas
+--0
 Content-Type: text/plain
 
 This is plain text.
---bananas--
+--0--
 
 Postlude
 END
 
   like($email->as_string, qr/Prelude/,  "prelude in string");
   like($email->as_string, qr/Postlude/, "postlude in string");
+
+  my @p;
+  $email->walk_parts(sub {
+    my $str = eval { $_[0]->body_str };
+    push @p, $str if defined $str;
+  });
+  is_deeply(\@p, ['This is plain text.']);
 
   $email->parts_set([ $email->subparts ]);
 


### PR DESCRIPTION
Why is stupid-big so slow?

I didn't like the splitting with `/...\s*$/m` but using a tighter `/\h*\v/` didn't help.

Trying a similarly large string in split didn't seem to indicate it was size alone.