### PR TITLE
Update MIME.pm

### DIFF
--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -449,7 +449,7 @@ sub filename {
   my ($self, $force) = @_;
   return $gcache{$self} if exists $gcache{$self};
 
-  my $dis = $self->header("Content-Disposition") || '';
+  my $dis = $self->header_raw("Content-Disposition") || '';
   my $attrs = parse_content_disposition($dis)->{attributes};
   my $name = $attrs->{filename}
     || $self->{ct}{attributes}{name};


### PR DESCRIPTION
If we are parsing content disposition, we should probably operate on raw value of header, not one already parsed.
This fixes problems with attachments names containing non-ASCII characters