### PR TITLE
do not allow an excessive number of parts

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 Revision history for Perl extension Email::MIME.
 
 {{$NEXT}}
+        - Fix for CVE-2024-4140: An excessive memory use issue (CWE-770)
+          exists in Email-MIME, before version 1.954, which can cause denial of
+          service when parsing multipart MIME messages.  The fix is the new
+          $MAX_PARTS configuration limits how many parts we will consider
+          parsing.  The default $MAX_PARTS is 100.
 
 1.953     2023-01-08 19:02:24-05:00 America/New_York
         - as promised, this release no longer works on v5.8; in fact, due to

--- a/lib/Email/MIME.pm
+++ b/lib/Email/MIME.pm
@@ -1060,6 +1060,14 @@ The variable C<$Email::MIME::MAX_DEPTH> is the maximum depth of parts that will
 be processed.  It defaults to 10, already higher than legitimate mail is ever
 likely to be.  This value may go up over time as the parser is improved.
 
+The variable C<$Email::MIME::MAX_PARTS> is the maximum number of parts that
+will be processed.  It defaults to 100, already higher than legitimate mail is
+ever likely to be.  This value may go up over time as the parser is improved or
+as research suggests that our starting position was wrong.
+
+Increasing either of these variables risks significant consumption of memory.
+Test before changing things.
+
 =head1 SEE ALSO
 
 L<Email::Simple>


### PR DESCRIPTION
This is annoying!  It bugs me that making a mere 100,000 parts should lead to excessive consumption of memory… but really, nobody does that for a good reason.

This makes top-level (non-recursive) Email::MIME->new set a localized part counter to 0 and increment before it makes new subpart objects. If the counter exceeds the max, it will die early.

It would be better to work, but this is better than eating all memory and crashing, right?

Put together with help from Marc Bradshaw.

Test forthcoming.

Fixes #66 